### PR TITLE
Set custom typescript version for umd build

### DIFF
--- a/dist/localforage-compatibility-1-4.js
+++ b/dist/localforage-compatibility-1-4.js
@@ -58,8 +58,8 @@ function config(localforageInstance) {
     });
 }
 var index = {
-    config,
-    isIndexedDBValid
+    config: config,
+    isIndexedDBValid: isIndexedDBValid
 };
 
 return index;

--- a/rollup.config.umd.js
+++ b/rollup.config.umd.js
@@ -11,6 +11,7 @@ export default {
   },
   // sourceMap: true,
   plugins: [typescript({
+    typescript: require('typescript'),
     tsconfig: false,
     "allowSyntheticDefaultImports": true,
     "module": "es2015",


### PR DESCRIPTION
`rollup-plugin-typescript` uses typescript 1.8.9, which does not transpile property shorthand correctly:
https://github.com/rollup/rollup-plugin-typescript/issues/40